### PR TITLE
Push v-leaflet dependency to version 0.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <dependency>
             <groupId>org.vaadin.addon</groupId>
             <artifactId>v-leaflet</artifactId>
-            <version>0.6.1</version>
+            <version>0.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.peimari</groupId>

--- a/src/main/java/org/vaadin/addon/leafletheat/client/LHeatLayerState.java
+++ b/src/main/java/org/vaadin/addon/leafletheat/client/LHeatLayerState.java
@@ -1,6 +1,6 @@
 package org.vaadin.addon.leafletheat.client;
 
-import org.vaadin.addon.leaflet.client.AbstractLeafletComponentState;
+import org.vaadin.addon.leaflet.shared.AbstractLeafletComponentState;
 
 public class LHeatLayerState extends AbstractLeafletComponentState {
     public String latlngJson;


### PR DESCRIPTION
Was not working with 0.6.3 before, because a class changed package. This fixes #5 
